### PR TITLE
bump uv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _Unreleased_
 
 - Fixed `rye config --show-path` abort with an error. #706
 
-- Bumped `uv` to 0.1.7.  #719, #740
+- Bumped `uv` to 0.1.9.  #719, #740, #746
 
 - Bumped `ruff` to 0.2.2.  #700
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _Unreleased_
 
 - Fixed `rye config --show-path` abort with an error. #706
 
-- Bumped `uv` to 0.1.6. #719
+- Bumped `uv` to 0.1.7.  #719, #740
 
 - Bumped `ruff` to 0.2.2.  #700
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -143,7 +143,7 @@ allows much easier cross-python version testing via tox or CI.
 
 Today there are a ton of different resolvers in the Python ecosystem.  Pip has two, poetry
 has one, pdm has one, different independent Python and Rust resolvers exist on top of that.
-Resolvers are important, but unfortunately are are both too many and too many issues with
+Resolvers are important, but unfortunately, there are both too many and too many issues with
 the existing ones.  Here is what I believe a resolver needs to be able to accomplish:
 
 * **Allow resolving across markers:** most resolvers in the Python ecosystem today can only

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -57,7 +57,7 @@ unearth==0.14.0
 urllib3==2.0.7
 virtualenv==20.25.0
 ruff==0.2.2
-uv==0.1.6
+uv==0.1.7
 "#;
 
 static FORCED_TO_UPDATE: AtomicBool = AtomicBool::new(false);

--- a/rye/src/bootstrap.rs
+++ b/rye/src/bootstrap.rs
@@ -57,7 +57,7 @@ unearth==0.14.0
 urllib3==2.0.7
 virtualenv==20.25.0
 ruff==0.2.2
-uv==0.1.7
+uv==0.1.9
 "#;
 
 static FORCED_TO_UPDATE: AtomicBool = AtomicBool::new(false);

--- a/rye/src/cli/init.rs
+++ b/rye/src/cli/init.rs
@@ -47,7 +47,7 @@ pub struct Args {
     /// Do not create .python-version file (requires-python will be used)
     #[arg(long)]
     no_pin: bool,
-    /// Which build system should be used(defaults to hatchling)?
+    /// Which build system should be used (defaults to hatchling)?
     #[arg(long)]
     build_system: Option<BuildSystem>,
     /// Which license should be used (SPDX identifier)?


### PR DESCRIPTION
- fix missing space in init --build-system flag description (#737)
- Fix typo & missing comma (#739)
- Bump `uv` to 0.1.7 (#740)
- Bump `uv` to 0.1.9
